### PR TITLE
feat: allow specifying a timestamp on metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ keywords = ["prometheus", "metrics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = {version = "0.4", optional = true}
+time = {version = "0.3", optional = true}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Why?
 
-In most cases exposing Prometheus metrics in Rust can be easily done using [the `prometheus` crate](https://docs.rs/prometheus/latest/prometheus/), using global counters registered as `lazy_static!`s or similar tricks. However this can have potential downsides to some use cases. 
+In most cases exposing Prometheus metrics in Rust can be easily done using [the `prometheus` crate](https://docs.rs/prometheus/latest/prometheus/), using global counters registered as `lazy_static!`s or similar tricks. However this can have potential downsides to some use cases.
 
 For example, you may want to set and unset metrics based on varying conditions, or register/unregister specific label sets. Such a task is tricky and cumbersome to achieve in the `prometheus` crate.
 
@@ -13,6 +13,7 @@ For example, you may want to set and unset metrics based on varying conditions, 
 Using `promformat` is pretty straightforward:
 
 ``` rust
+use std::time::SystemTime;
 use promformat::Metrics;
 
 let mut metrics = Metrics::new();
@@ -20,6 +21,8 @@ let mut metrics = Metrics::new();
 let mut gauge1 = metrics.gauge("gauge_1", "Some gauge help text here");
 gauge1.label("label1", "value1").label("label2", "value2").set(100);
 
+let mut gauge2 = metrics.gauge("gauge_2", "Some other gaueg here");
+gauge2.label("label2", "value2").set_with_timestamp(100, SystemTime::now());
 
 
 let rendered = metrics.render();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,34 @@
 use std::fmt::Write;
 
+pub trait TimestampLike {
+    fn as_prometheus_timestamp(&self) -> i64;
+}
+
+impl TimestampLike for std::time::SystemTime {
+    fn as_prometheus_timestamp(&self) -> i64 {
+        self.duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl<H: chrono::TimeZone> TimestampLike for chrono::DateTime<H> {
+    fn as_prometheus_timestamp(&self) -> i64 {
+        self.timestamp_millis()
+    }
+}
+
+#[cfg(feature = "time")]
+const NANOS_PER_MILLI: i128 = 1_000_000;
+
+#[cfg(feature = "time")]
+impl TimestampLike for time::OffsetDateTime {
+    fn as_prometheus_timestamp(&self) -> i64 {
+        (self.unix_timestamp_nanos() / NANOS_PER_MILLI) as i64
+    }
+}
+
 #[derive(Default)]
 pub struct Metrics {
     buffer: String,
@@ -72,6 +101,15 @@ impl<'a> MetricGroup<'a> {
         }
         .set(value)
     }
+
+    pub fn set_with_timestamp(self, value: impl std::fmt::Display, timestamp: impl TimestampLike) {
+        SingleMetric {
+            name: &self.name,
+            metrics: self.metrics,
+            labels: String::from("{"),
+        }
+        .set_with_timestamp(value, timestamp)
+    }
 }
 
 pub struct SingleMetric<'a, 'b> {
@@ -99,6 +137,21 @@ impl<'a, 'b> SingleMetric<'a, 'b> {
     pub fn set(mut self, value: impl std::fmt::Display) {
         self.labels.push('}');
         writeln!(self.metrics.buffer, "{}{} {value}", self.name, self.labels).unwrap();
+    }
+
+    pub fn set_with_timestamp(
+        mut self,
+        value: impl std::fmt::Display,
+        timestamp: impl TimestampLike,
+    ) {
+        self.labels.push('}');
+        let unix_millis = timestamp.as_prometheus_timestamp();
+        writeln!(
+            self.metrics.buffer,
+            "{}{} {value} {unix_millis}",
+            self.name, self.labels
+        )
+        .unwrap();
     }
 }
 
@@ -135,6 +188,69 @@ testme{a="b",c="d"} 20
             r#"# HELP testme help here
 # TYPE testme gauge
 testme{} 20
+"#
+        );
+    }
+
+    #[test]
+    fn test_gauge_timestamp_systemtime() {
+        let mut metrics = Metrics::default();
+        let now = std::time::UNIX_EPOCH + std::time::Duration::from_secs(259200);
+
+        metrics
+            .gauge("testme", "help here")
+            .set_with_timestamp(20, now);
+
+        assert_eq!(
+            metrics.render(),
+            r#"# HELP testme help here
+# TYPE testme gauge
+testme{} 20 259200000
+"#
+        );
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_gauge_timestamp_chrono() {
+        use chrono::{TimeZone, Utc};
+
+        let mut metrics = Metrics::default();
+        let now = Utc.with_ymd_and_hms(2025, 8, 19, 21, 31, 5).unwrap();
+
+        metrics
+            .gauge("testme", "help here")
+            .set_with_timestamp(20, now);
+
+        assert_eq!(
+            metrics.render(),
+            r#"# HELP testme help here
+# TYPE testme gauge
+testme{} 20 1755639065000
+"#
+        );
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn test_gauge_timestamp_time() {
+        use time::{Date, Month, OffsetDateTime, Time};
+
+        let mut metrics = Metrics::default();
+        let now = OffsetDateTime::new_utc(
+            Date::from_calendar_date(2025, Month::August, 19).unwrap(),
+            Time::from_hms_nano(21, 31, 5, 0).unwrap(),
+        );
+
+        metrics
+            .gauge("testme", "help here")
+            .set_with_timestamp(20, now);
+
+        assert_eq!(
+            metrics.render(),
+            r#"# HELP testme help here
+# TYPE testme gauge
+testme{} 20 1755639065000
 "#
         );
     }


### PR DESCRIPTION
This allows you to set a metric with a timestamp. It supports `SystemTime` natively and adds features for `chrono` and `time` support